### PR TITLE
Updated PR Pipeline to use vars instead of environment variables.

### DIFF
--- a/.actrc
+++ b/.actrc
@@ -1,0 +1,3 @@
+--container-architecture linux/amd64
+-P ubuntu-latest=catthehacker/ubuntu:act-latest
+--rm

--- a/.github/workflows/pr_testing.yaml
+++ b/.github/workflows/pr_testing.yaml
@@ -52,7 +52,7 @@ jobs:
       - name: Docker Login
         uses: docker/login-action@v3
         with:
-          username: ${{ env.DOCKER_USERNAME }}
+          username: ${{ vars.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Docker Scout


### PR DESCRIPTION
Updated PR pipeline to correctly use `vars` instead of `env` for variable declaration for Docker scout.
