### PR TITLE
Pinned Tenint Library to Version 0.1.6

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,5 +1,5 @@
 FROM python:3.12-alpine AS connector-base
-RUN pip install uv && uv pip install --system tenint
+RUN pip install uv && uv pip install --system "tenint==0.1.6"
 RUN addgroup -S connector && adduser connector -S -G connector -h /connector
 
 


### PR DESCRIPTION
Added pinning to the Tenint library version that the connectors are building against.  Should solve for any future issues in which the library ends up ahead of the mono-repo