### PR TITLE
Updated Deployment Parallelization

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -54,6 +54,7 @@ jobs:
     continue-on-error: true
     needs: [connector-list, snyk]
     strategy:
+      max-parallel: 1
       matrix:
         connector: ${{ fromJSON(needs.connector-list.outputs.connectors) }}
 

--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,14 +1,30 @@
+# Connector Base Stage
+# --------------------
+# This stage installs the base minimum that is common for every connector.
 FROM python:3.12-alpine AS connector-base
 
 ARG UV_SYSTEM_PYTHON=true
 RUN pip install uv && uv pip install "tenint==0.9.0"
 
 
+# Connector Build Stage
+# ---------------------
+# This stage installs both the connector code and the dependent libraries needed
+# to ensure that the connector will run.
 FROM connector-base AS build
 ADD ./ /connector/
 RUN uv pip install -r /connector/pyproject.toml
 
 
+# Connector Test Stage
+# --------------------
+# In this stage we will install any required testing libraries and tools and
+# run the following suite of security and testing tools:
+#
+# * ruff check :: Code linting and formatting
+# * pytest     :: Unit testing and test coverage
+# * pip-audit  :: Ensure none of the libraries installed have any security issues
+# * bandit     :: Check the code for any potential low-hanging security code issues
 FROM build AS test
 WORKDIR /connector/
 RUN uv pip install "tenint[testing]" \
@@ -23,7 +39,11 @@ RUN tenint marketplace
 RUN echo $(date '+Y-%m-%d %H:%M%S') > /tested_on
 
 
-FROM python:3.12-alpine
+# Final Image (publish) Stage
+# ---------------------------
+# In this stage we will pull the installed libraries and code from the relevent
+# stages above and configure the image to use a non-root user.
+FROM python:3.12-alpine AS publish
 
 RUN addgroup -S connector && adduser connector -S -G connector -h /connector
 USER connector:connector


### PR DESCRIPTION
# Description

Updated the maximum number of parallel connector builds that may be run during the deployment phase as the image
publisher can only run a single deployment at a time.

Also added some additional comments within the Dockerfile in order to better describe what the differen stages are
doing when building a connector.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
