### PR TITLE
Updated the vagrant file to use an Alma9 image that works for both ARM64 and AMD64

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,3 +50,39 @@ minimum meet are the following:
 ## How to develop a connector
 
 **NOTE** Will be written when we're ready to start accepting outside written integrations
+
+## Running the testing TIF instance
+
+There is an included vagrant file to help enable quick testing of connector images. This VM image exposes Cockpit on
+port `9090` and can be interfaced by pointing a web browser to `https://localhost:9090`. A random root password is
+also generated and presented as the last line in the setup process for the VM. Look for a line in the provisioning
+output that looks like:
+
+```
+default: root password is set to 'ZDU3OTU5OWZjZTE0YTkxZTU3ZjJhMjEw'
+```
+
+### Initial Install and Setup on MacOS
+
+1. Install `brew`
+2. Install QEMU `brew install qemu libvirt`
+3. Install Vagrant `brew install --cask vagrant`
+4. Install the Vagrant QEMU plugin `vagrant plugin install vagrant-qemu`
+
+### Deploying a new VM
+
+```
+vagrant up --provider=qemu
+```
+
+### Stopping the VM
+
+```
+vagrant halt
+```
+
+### Destroying the VM
+
+```
+vagrant destroy
+```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,19 +1,25 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/rockylinux-9"
+  #config.vm.box = "bento/rockylinux-9"
+  config.vm.box = "generic/alma9"
   config.vm.network "forwarded_port", guest: 9090, host: 9090
   config.vm.synced_folder ".", "/vagrant", disabled: true
   config.vm.box_check_update = true
 
   config.vm.provider "virtualbox" do |vb|
     vb.memory = "4096"
+    vb.gui = true
   end
   config.vm.provider "parallels" do |pl|
     pl.memory = "4096"
   end
   config.vm.provider "vmware_desktop" do |vmw|
-    vmw.memory = "4096"
+    vmw.vmx['memsize'] = "4096"
+    vmw.gui = true
+  end
+  config.vm.provider "qemu" do |qemu|
+    qemu.memory = 4096
   end
 
   config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
# Description

Previous vagrant base image had issues with some providers. Switched the image to use an alma9 base that is supported
by QEMU for both common architectures instead.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Tested with QEMU on MacOS w/ an M1 CPU. Built and deployed successfully.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
