### PR TITLE
Add support to fetch vuln from CrowdStrike and ingest into T1

### DIFF
--- a/connectors/crowdstrike2tone/README.md
+++ b/connectors/crowdstrike2tone/README.md
@@ -1,7 +1,4 @@
 # Crowdstrike -> T1 Ingest Connector
 
-This connector code will download the assets from Crowdstrike,
+This connector code will download the assets and vulnerabilities from Crowdstrike,
 transform then upload to T1.
-
-All job management is handled by the pyTenable sync JobManager (currently within the
-`feature/sync` branch).

--- a/connectors/crowdstrike2tone/connector.py
+++ b/connectors/crowdstrike2tone/connector.py
@@ -55,6 +55,16 @@ class AppSettings(Settings):
         int, Field(description='How many days back to get assets/findings', ge=1, le=7)
     ] = 1
 
+    import_findings: Annotated[
+        bool,
+        Field(
+            title='Import Findings',
+            description=(
+                'Check Whether or Not To Import the CrowdStrike Vulnerability Findings'
+            ),
+        ),
+    ] = True
+
 
 connector = Connector(
     settings=AppSettings, credentials=[CrowdstrikeCredential, TenableCloudCredential]
@@ -67,7 +77,9 @@ def main(config: AppSettings, since: int | None = None):
     Crowdstrike to Tenable One Connector
     """
     transformer = Transformer()
-    counts = transformer.run(get_findings=False, last_seen_days=config.last_seen_days)
+    counts = transformer.run(
+        get_findings=config.import_findings, last_seen_days=config.last_seen_days
+    )
     return {'counts': counts}
 
 

--- a/connectors/crowdstrike2tone/crowdstrike/__init__.py
+++ b/connectors/crowdstrike2tone/crowdstrike/__init__.py
@@ -1,3 +1,3 @@
 # from .api.session import CrowdStrikeAPI
 
-__version__ = '1.0.1'
+__version__ = '1.1.0'

--- a/connectors/crowdstrike2tone/crowdstrike/api/assets.py
+++ b/connectors/crowdstrike2tone/crowdstrike/api/assets.py
@@ -1,10 +1,12 @@
-from typing import Optional, List, Dict, Union
-from requests import Response
-from box import Box, BoxList
+from typing import Dict, List, Optional, Union
+
 import arrow
-from crowdstrike.api.iterator import CrowdstrikeAssetIterator
-from restfly.errors import BadRequestError
+from box import Box, BoxList
+from requests import Response
 from restfly.endpoint import APIEndpoint
+from restfly.errors import BadRequestError
+
+from crowdstrike.api.iterator import CrowdstrikeAssetIterator
 
 
 class AssetsAPI(APIEndpoint):
@@ -20,11 +22,12 @@ class AssetsAPI(APIEndpoint):
         Get all hosts
 
         Args:
-            limit (int): the number of items to return. This should never be more than 5000
-            as the following api call to get details only accepts max 5000
+            limit (int): the number of items to return. This should never be more than
+            5000 as the following api call to get details only accepts max 5000
             sort (str, optional): the FQL sort parameter
-            last_seen_days (int, optional): the number of days back to search back if filter isnt provided.
-            filter (str, optional): The filter string in FQL format to filter CS assets with
+            last_seen_days (int, optional): the number of days back to search back
+            if filter isn't provided.
+            filter (str, optional): The filter string in FQL format to filter CS assets
         Returns:
             CrowdstrikeAssetIterator
 

--- a/connectors/crowdstrike2tone/crowdstrike/api/assets.py
+++ b/connectors/crowdstrike2tone/crowdstrike/api/assets.py
@@ -22,12 +22,14 @@ class AssetsAPI(APIEndpoint):
         Get all hosts
 
         Args:
-            limit (int): the number of items to return. This should never be more than
-            5000 as the following api call to get details only accepts max 5000
+            limit (int):
+                the number of items to return. This should never be more than 5000
+                as the following api call to get details only accepts max 5000
             sort (str, optional): the FQL sort parameter
-            last_seen_days (int, optional): the number of days back to search back
-            if filter isn't provided.
-            filter (str, optional): The filter string in FQL format to filter CS assets
+            last_seen_days (int, optional):
+                the number of days back to search back if filter isn't provided.
+            filter (str, optional):
+                The filter string in FQL format to filter CS assets
         Returns:
             CrowdstrikeAssetIterator
 

--- a/connectors/crowdstrike2tone/crowdstrike/api/findings.py
+++ b/connectors/crowdstrike2tone/crowdstrike/api/findings.py
@@ -3,7 +3,7 @@ from typing import Literal, Optional
 import arrow
 from restfly.endpoint import APIEndpoint
 
-from crowdstrike.api.iterator import CrowdstrikeFindingIterator
+from .iterator import CrowdstrikeFindingIterator
 
 
 class FindingsAPI(APIEndpoint):
@@ -12,6 +12,8 @@ class FindingsAPI(APIEndpoint):
     Spotlight API. This API provides the ability to retrieve a list of vulnerabilities,
     sort and filter the results by specified criteria.
     """
+
+    _path = 'spotlight/combined/vulnerabilities/v1'
 
     def vulns(
         self,
@@ -23,19 +25,20 @@ class FindingsAPI(APIEndpoint):
         Retrieves a list of vulnerabilities.
 
         Args:
-            limit: The maximum number of items to return. Defaults to 100,
-                maximum of 5000.
-            sort: The sort parameter, either ``updated_timestamp|asc`` or
-                ``closed_timestamp|asc``. Defaults to ``None``.
-            filter: The filter string in FQL format to filter CS findings with.
+            limit:
+                The maximum number of items to return. Defaults to 100, maximum of 5000.
+            sort:
+                The sort parameter, either ``updated_timestamp|asc`` or ``closed_timestamp|asc``.
                 Defaults to ``None``.
-            facet: The list of fields to facet the results by. Defaults to ``None``.
+            filter:
+                The filter string in FQL format to filter CS findings with.
+                Defaults to ``None``.
+            facet:
+                The list of fields to facet the results by. Defaults to ``None``.
 
         Returns:
             CrowdstrikeFindingIterator
         """
-        _path = 'spotlight/combined/vulnerabilities/v1'
-
         status_filter = 'status:["open","reopen"]'
 
         if limit > 5000:
@@ -50,5 +53,5 @@ class FindingsAPI(APIEndpoint):
         )
         params['filter'] = f'updated_timestamp:>"{last_seen}"+{status_filter}'
         return CrowdstrikeFindingIterator(
-            self._api, _envelope='resources', _path=_path, _params=params
+            self._api, _envelope='resources', _path=self._path, _params=params
         )

--- a/connectors/crowdstrike2tone/crowdstrike/api/findings.py
+++ b/connectors/crowdstrike2tone/crowdstrike/api/findings.py
@@ -1,8 +1,54 @@
-from restfly.endpoint import APIEndpoint, APISession
+from typing import Literal, Optional
+
+import arrow
+from restfly.endpoint import APIEndpoint
+
+from crowdstrike.api.iterator import CrowdstrikeFindingIterator
 
 
 class FindingsAPI(APIEndpoint):
-    _path = 'asset/host/vm/detection/'
+    """
+    The Findings API provides the ability to interact with the CrowdStrike Falcon
+    Spotlight API. This API provides the ability to retrieve a list of vulnerabilities,
+    sort and filter the results by specified criteria.
+    """
 
-    def __init__(self, api: APISession):
-        raise NotImplementedError()
+    def vulns(
+        self,
+        limit: int = 5000,
+        sort: Optional[Literal['updated_timestamp|asc', 'closed_timestamp|asc']] = None,
+        last_seen_days: Optional[int] = 1,
+    ) -> CrowdstrikeFindingIterator:
+        """
+        Retrieves a list of vulnerabilities.
+
+        Args:
+            limit: The maximum number of items to return. Defaults to 100,
+                maximum of 5000.
+            sort: The sort parameter, either ``updated_timestamp|asc`` or
+                ``closed_timestamp|asc``. Defaults to ``None``.
+            filter: The filter string in FQL format to filter CS findings with.
+                Defaults to ``None``.
+            facet: The list of fields to facet the results by. Defaults to ``None``.
+
+        Returns:
+            CrowdstrikeFindingIterator
+        """
+        _path = 'spotlight/combined/vulnerabilities/v1'
+
+        status_filter = 'status:["open","reopen"]'
+
+        if limit > 5000:
+            self._log.warning(
+                f'limit must be <= 5000; {limit} provided. Setting to 5000.'
+            )
+            limit = 5000
+        params = {'limit': limit, 'sort': sort, 'facet': 'cve'}
+
+        last_seen = (
+            arrow.utcnow().shift(days=-last_seen_days).format('YYYY-MM-DDTHH:mm:ssZ')
+        )
+        params['filter'] = f'updated_timestamp:>"{last_seen}"+{status_filter}'
+        return CrowdstrikeFindingIterator(
+            self._api, _envelope='resources', _path=_path, _params=params
+        )

--- a/connectors/crowdstrike2tone/crowdstrike/transform.py
+++ b/connectors/crowdstrike2tone/crowdstrike/transform.py
@@ -48,9 +48,10 @@ class Transformer:
         Main entry point for the transformer.
 
         Args:
-            get_findings (bool): Should we import findings into T1 as well?
-            last_seen_days (int): The number of days to go back when collecting
-            assets and findings.
+            get_findings (bool):
+                Should we import findings into T1 as well?
+            last_seen_days (int):
+                The number of days to go back when collecting assets and findings.
 
         Returns:
             dict: The counts of assets and findings imported.
@@ -173,23 +174,17 @@ class Transformer:
                     {
                         'product': {
                             # Normalize the product name and vendor to 32 characters
-                            'product_name': trunc(
-                                str(app.get('vendor_normalized', '')), 32
-                            ),
-                            'vendor_name': trunc(
-                                str(app.get('product_name_version', '')), 32
-                            ),
-                            'version': trunc(
-                                str(app.get('product_name_normalized', '')), 32
-                            ),
+                            'product_name': app.get('vendor_normalized'),
+                            'vendor_name': app.get('product_name_version'),
+                            'version': app.get('product_name_normalized'),
                         }
                     }
                 )
-        CVE_ID = finding.get('cve', {}).get('id')
-        SEVERITY = finding.get('cve', {}).get('severity')
+        cve_id = finding.get('cve', {}).get('id')
+        severity = finding.get('cve', {}).get('severity')
         # Normalize the severity
-        if SEVERITY:
-            SEVERITY = SEVERITY if SEVERITY != 'UNKNOWN' else 'NONE'
+        if severity:
+            severity = severity if severity != 'UNKNOWN' else 'NONE'
 
         # Return the transformed finding
         return {
@@ -204,7 +199,7 @@ class Transformer:
                 'last_observed_on': finding.get('updated_timestamp'),
             },
             'id': finding['id'],
-            'cve': {'cves': [CVE_ID]} if CVE_ID else None,
+            'cve': {'cves': [cve_id]} if cve_id else None,
             'observations': observations if observations else None,
-            'exposure': {'severity': {'level': SEVERITY} if SEVERITY else None},
+            'exposure': {'severity': {'level': severity} if severity else None},
         }

--- a/connectors/crowdstrike2tone/crowdstrike/transform.py
+++ b/connectors/crowdstrike2tone/crowdstrike/transform.py
@@ -19,7 +19,13 @@ class Transformer:
         tvm: TenableIO | None = None,
         crwd: CrowdStrikeAPI | None = None,
     ) -> None:
-        """ """
+        """
+        Initialize the transformer.
+
+        Args:
+            tvm: Optional TenableIO session to use.
+            crwd: Optional CrowdStrikeAPI session to use.
+        """
         self.tvm = (
             tvm
             if tvm
@@ -34,44 +40,59 @@ class Transformer:
         self.counts = {}
 
     def run(
-        self, get_findings: bool = True, last_seen_days: int = 1
+        self,
+        get_findings: bool = True,
+        last_seen_days: int = 1,
     ) -> dict[str, dict[str, int]]:
+        """
+        Main entry point for the transformer.
+
+        Args:
+            get_findings (bool): Should we import findings into T1 as well?
+            last_seen_days (int): The number of days to go back when collecting
+            assets and findings.
+
+        Returns:
+            dict: The counts of assets and findings imported.
+        """
         job = self.tvm.sync.create(sync_id='tenable_crowdstrike_falcon')
         with job:
+            # Process the assets
             for asset in self.crwd.assets.list(last_seen_days=last_seen_days):
                 t1asset = self.transform_asset(asset)
                 self.log.debug('Adding asset id=%s to the job' % t1asset['id'])
                 job.add(t1asset, object_type='device-asset')
-            # if not get_findings:
-            #    return
-            # raise NotImplementedError()
-            # for vuln in self.crwd.findings.vulns():
-            #    finding = self.transform_finding(vuln)
-            #    self.log.debug(
-            #        'Adding finding id=%s to asset id=%s'
-            #        % (finding['id'], vuln['machineId'])
-            #    )
-            #    job.add(finding, object_type='cve-finding')
 
-        # Lastly we will update the asset and findings counters and return the counts.
-        self.counts['assets'] = {'sent': job.counters['device-asset']['accepted']}
-        self.counts['findings'] = {'sent': job.counters['cve-finding']['accepted']}
+            self.counts['assets'] = {'sent': job.counters['device-asset']['accepted']}
+
+            # Process the findings
+            if get_findings:
+                for vuln in self.crwd.findings.vulns(last_seen_days=last_seen_days):
+                    finding = self.transform_finding(vuln)
+                    self.log.debug(
+                        'Adding finding id=%s to asset id=%s'
+                        % (finding['id'], vuln['aid'])
+                    )
+                    job.add(finding, object_type='cve-finding')
+                self.counts['findings'] = {
+                    'sent': job.counters['cve-finding']['accepted']
+                }
         return self.counts
 
     def derive_system_type(self, system_type: str) -> str:
         """
-        Attempts to derive the system type as required by the T1 Sync API.  If unsuccessful
-        then we will return 'UNKNOWN'.
+        Attempts to derive the system type as required by the T1 Sync API.
+        If unsuccessful then we will return 'UNKNOWN'.
         """
         type_map = {'windows': 'WINDOWS', 'linux': 'LINUX', 'macos': 'MAC_OS'}
         for key, value in type_map.items():
-            if system_type.lower() in key:
+            if key in system_type.lower():
                 return value
         return 'UNKNOWN'
 
     def transform_asset(self, asset: dict[str, Any]) -> dict[str, Any]:
         """
-        Converts a CS machine into a T1 compatable asset format.
+        Converts a CS machine into a T1 compatible asset format.
         """
         ip_map = {'IPv4Address': 'ip_addresses_v4', 'IPv6Address': 'ip_addresses_v6'}
         ret = {
@@ -127,27 +148,63 @@ class Transformer:
 
     def transform_finding(self, finding: dict) -> dict:
         """
-        Converts an MS Defender finding into a T1 compatable format.
+        Converts a CrowdStrike finding into a T1 compatible format.
+
+        This function takes a CrowdStrike finding and transforms it into a
+        T1-compatible CVE finding. It extracts the relevant information from the
+        finding, such as the asset ID, state, discovery timestamps, and CVE ID.
+        It then returns a dictionary that is compatible with the T1 API.
+
+        :param finding: A dictionary containing the CrowdStrike vulnerability.
+        :return: A dictionary containing the transformed finding.
         """
-        raise NotImplementedError()
-        # return {
-        #    'object_type': 'cve-finding',
-        #    'asset_id': finding['machineId'],
-        #    'id': str(uuid3(self.NAMESPACE, finding['id'])),
-        #    'cve': {'cves': [finding['cveId']]},
-        #    'exposure': {'severity': {'level': str(finding['severity'].upper())}},
-        #    'observations': {
-        #        'software': [
-        #            {
-        #                'product': {
-        #                    'product_name': trunc(str(finding['productName']), 32),
-        #                    'vendor_name': trunc(str(finding['productVendor']), 32),
-        #                    'version': trunc(str(finding['productVersion']), 32),
-        #                },
-        #            },
-        #        ],
-        #    },
-        # }
+        # Map CrowdStrike finding status to T1 finding state
+        status_switch = {
+            'open': 'ACTIVE',
+            'reopen': 'REOPENED',
+        }
 
+        # Extract the relevant information from the finding
+        observations = {}
+        if finding.get('apps'):
+            observations['software'] = []
+            for app in finding['apps']:
+                observations['software'].append(
+                    {
+                        'product': {
+                            # Normalize the product name and vendor to 32 characters
+                            'product_name': trunc(
+                                str(app.get('vendor_normalized', '')), 32
+                            ),
+                            'vendor_name': trunc(
+                                str(app.get('product_name_version', '')), 32
+                            ),
+                            'version': trunc(
+                                str(app.get('product_name_normalized', '')), 32
+                            ),
+                        }
+                    }
+                )
+        CVE_ID = finding.get('cve', {}).get('id')
+        SEVERITY = finding.get('cve', {}).get('severity')
+        # Normalize the severity
+        if SEVERITY:
+            SEVERITY = SEVERITY if SEVERITY != 'UNKNOWN' else 'NONE'
 
-#
+        # Return the transformed finding
+        return {
+            'object_type': 'cve-finding',
+            'asset_id': finding['aid'],
+            'definition_urn': f'urn:crowdstrike:{finding["vulnerability_id"]}',
+            # Use the status switch to map the CrowdStrike finding status to
+            # T1 finding state
+            'state': status_switch.get(finding.get('status', ''), 'ACTIVE'),
+            'discovery': {
+                'first_observed_at': finding.get('created_timestamp'),
+                'last_observed_on': finding.get('updated_timestamp'),
+            },
+            'id': finding['id'],
+            'cve': {'cves': [CVE_ID]} if CVE_ID else None,
+            'observations': observations if observations else None,
+            'exposure': {'severity': {'level': SEVERITY}},
+        }

--- a/connectors/crowdstrike2tone/crowdstrike/transform.py
+++ b/connectors/crowdstrike2tone/crowdstrike/transform.py
@@ -206,5 +206,5 @@ class Transformer:
             'id': finding['id'],
             'cve': {'cves': [CVE_ID]} if CVE_ID else None,
             'observations': observations if observations else None,
-            'exposure': {'severity': {'level': SEVERITY}},
+            'exposure': {'severity': {'level': SEVERITY} if SEVERITY else None},
         }

--- a/connectors/crowdstrike2tone/pyproject.toml
+++ b/connectors/crowdstrike2tone/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "crowdstrike2tone"
-version = "1.0.1"
+version = "1.1.0"
 description = "Crowdstrike -> Tenable One"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/connectors/crowdstrike2tone/tests/api/test_findings.py
+++ b/connectors/crowdstrike2tone/tests/api/test_findings.py
@@ -1,1 +1,51 @@
+import arrow
+import responses
+from responses.matchers import query_param_matcher
 
+
+@responses.activate
+def test_findings_vulns_without_filter(csapi, finding_details_page, last_seen_days=1):
+    last_seen = (
+        arrow.utcnow().shift(days=-last_seen_days).format('YYYY-MM-DDTHH:mm:ssZ')
+    )
+    responses.get(
+        url='https://nourl.crowdstrike/spotlight/combined/vulnerabilities/v1',
+        match=[
+            query_param_matcher(
+                {
+                    'limit': 5000,
+                    'filter': f'updated_timestamp:>"{last_seen}"+status:["open","reopen"]',
+                    'facet': 'cve',
+                },
+                strict_match=False,
+            )
+        ],
+        json=finding_details_page,
+    )
+    resp = csapi.findings.vulns()
+    for item in resp:
+        assert isinstance(item, dict)
+
+
+@responses.activate
+def test_findings_vulns_with_filter(csapi, finding_details_page, last_seen_days=2):
+    last_seen = (
+        arrow.utcnow().shift(days=-last_seen_days).format('YYYY-MM-DDTHH:mm:ssZ')
+    )
+    responses.get(
+        url='https://nourl.crowdstrike/spotlight/combined/vulnerabilities/v1',
+        match=[
+            query_param_matcher(
+                {
+                    'limit': 5000,
+                    'filter': f'updated_timestamp:>"{last_seen}"+status:["open","reopen"]',
+                    'facet': 'cve',
+                },
+                strict_match=False,
+            )
+        ],
+        json=finding_details_page,
+    )
+    resp = csapi.findings.vulns(limit=6000, last_seen_days=last_seen_days)
+    for item in resp:
+        assert isinstance(item, dict)

--- a/connectors/crowdstrike2tone/tests/conftest.py
+++ b/connectors/crowdstrike2tone/tests/conftest.py
@@ -132,7 +132,9 @@ def asset_details():
                 'assigned_date': '2024-12-08T00:06:08.857961164Z',
                 'policy_id': '0e31ef23c8d141c6b7950118aac92153',
                 'policy_type': 'host-retention',
-                'settings_hash': 'fce339fc6cbb4dae36929fe363a81368f4a7e3f2c3a3d62ff7e3ef202ee48df5',
+                'settings_hash': (
+                    'fce339fc6cbb4dae36929fe363a81368f4a7e3f2c3a3d62ff7e3ef202ee48df5'
+                ),
             },
             'prevention': {
                 'applied': False,
@@ -164,7 +166,9 @@ def asset_details():
         'external_ip': '8.8.8.8',
         'filesystem_containment_status': 'normal',
         'first_seen': '2024-12-08T00:05:01Z',
-        'group_hash': 'ead77444393c2a351deebf62b361eef72de1a99022e13a652e6c317242c98cd1',
+        'group_hash': (
+            'ead77444393c2a351deebf62b361eef72de1a99022e13a652e6c317242c98cd1'
+        ),
         'groups': ['2fd37c5cf03b48d69d2ce0a09d400dbd'],
         'hostname': 'ip-10-1-1-2.us-east-2.compute.internal',
         'instance_id': 'i-example4f7a67bed',
@@ -235,4 +239,64 @@ def asset_details_page_one(asset_details):
         },
         'resources': [asset_details],
         'errors': [],
+    }
+
+
+@pytest.fixture
+def finding_details():
+    return {
+        'id': '897580',
+        'cid': '2cc98',
+        'aid': '897580de18',
+        'vulnerability_id': 'CVE-2024-50222',
+        'data_providers': [{'provider': 'Falcon sensor'}],
+        'created_timestamp': '2025-01-09T09:12:55Z',
+        'updated_timestamp': '2025-02-21T00:48:53Z',
+        'status': 'Open',
+        'apps': [
+            {
+                'vendor_normalized': 'Ubuntu',
+                'product_name_version': 'linux-signed 6.8.0-51.52',
+                'product_name_normalized': 'linux-signed',
+                'sub_status': 'open',
+                'remediation': {},
+                'evaluation_logic': {'id': ''},
+            }
+        ],
+        'suppression_info': {'is_suppressed': False},
+        'confidence': 'confirmed',
+        'cve': {
+            'id': 'CVE-2024-50222',
+            'base_score': 7.8,
+            'severity': 'HIGH',
+            'exploit_status': 0,
+            'exprt_rating': 'MEDIUM',
+            'remediation_level': 'U',
+            'cisa_info': {'is_cisa_kev': False},
+            'spotlight_published_date': '2024-11-13T17:09:00Z',
+            'types': ['Vulnerability'],
+            'cwes': ['CWE-399'],
+            'description': (
+                'In the Linux kernel, the following vulnerability has outlived its '
+                'usefulness, and should just be removed?\n'
+            ),
+            'published_date': '2024-11-09T00:00:00Z',
+            'references': ['https://www.cve.org/CVERecord?id=CVE-2024-50222'],
+            'exploitability_score': 1.8,
+            'impact_score': 5.9,
+            'vector': 'CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:H/I:H/A:H',
+        },
+    }
+
+
+@pytest.fixture
+def finding_details_page(finding_details):
+    return {
+        'meta': {
+            'query_time': 0.221030971,
+            'pagination': {'limit': 2, 'total': 3, 'after': 'example_after_token'},
+            'powered_by': 'finding-api',
+            'trace_id': 'example_trace_id',
+        },
+        'resources': [finding_details],
     }

--- a/connectors/crowdstrike2tone/tests/test_transform.py
+++ b/connectors/crowdstrike2tone/tests/test_transform.py
@@ -1,4 +1,5 @@
 import pytest
+from tenable.io.sync.models.cve_finding import CVEFinding
 from tenable.io.sync.models.device_asset import DeviceAsset
 
 from crowdstrike.transform import Transformer
@@ -7,6 +8,52 @@ from crowdstrike.transform import Transformer
 @pytest.fixture
 def transformer(csapi, tapi):
     return Transformer(crwd=csapi, tvm=tapi)
+
+
+def compare_dicts(dict1, dict2) -> bool:
+    """Compare tow dictionaries recursively."""
+    if dict1.keys() != dict2.keys():
+        return False
+
+    for key in dict1:
+        if isinstance(dict1[key], dict) and isinstance(dict2[key], dict):
+            if not compare_dicts(dict1[key], dict2[key]):
+                return False
+        elif isinstance(dict1[key], list) and isinstance(dict2[key], list):
+            if not compare_lists(dict1[key], dict2[key], True):
+                return False
+        elif dict1[key] != dict2[key]:
+            return False
+
+    return True
+
+
+def compare_lists(list1, list2, key_to_compare=None):
+    """
+    Compare lists, handling lists of dictionaries
+    (e.g., ip_addresses_v4) and regular lists.
+    """
+    if len(list1) != len(list2):
+        return False
+
+    # Check if the list contains dictionaries
+    if isinstance(list1[0], dict) and isinstance(list2[0], dict):
+        # For lists of dictionaries, compare based on a specific key if provided
+        if key_to_compare:
+            # Compare using the specified key from each dictionary
+            list1_values = sorted(
+                [item.get(key_to_compare) for item in list1 if key_to_compare in item]
+            )
+            list2_values = sorted(
+                [item.get(key_to_compare) for item in list2 if key_to_compare in item]
+            )
+            return list1_values == list2_values
+        else:
+            # If no key is provided, compare all dictionary fields
+            return sorted(list1) == sorted(list2)
+    else:
+        # For regular lists (not dictionaries), compare them directly
+        return sorted(list1) == sorted(list2)
 
 
 def test_transform_asset(transformer, asset_details):
@@ -45,8 +92,42 @@ def test_transform_asset(transformer, asset_details):
 
     t = transformer.transform_asset(asset_details)
     a = DeviceAsset(**t).model_dump(mode='json', exclude_none=True)
-    assert tnx_asset['device'] == a['device']
-    assert tnx_asset['discovery'] == a['discovery']
-    assert len(tnx_asset['labels']) == len(a['labels'])
-    assert tnx_asset['id'] == a['id']
-    assert tnx_asset['name'] == a['name']
+    assert compare_dicts(a, tnx_asset)
+
+
+def test_transform_finding(transformer, finding_details):
+    tnx_finding = {
+        'object_type': 'cve-finding',
+        'asset_id': '897580de18',
+        'definition_urn': 'urn:crowdstrike:CVE-2024-50222',
+        'state': 'ACTIVE',
+        'discovery': {
+            'first_observed_at': '2025-01-09T09:12:55Z',
+            'last_observed_on': '2025-02-21T00:48:53Z',
+        },
+        'id': '897580',
+        'cve': {'cves': ['CVE-2024-50222']},
+        'observations': {
+            'software': [
+                {
+                    'product': {
+                        'product_name': 'Ubuntu',
+                        'vendor_name': 'linux-signed 6.8.0-51.52',
+                        'version': 'linux-signed',
+                    }
+                }
+            ]
+        },
+        'exposure': {'severity': {'level': 'HIGH'}},
+    }
+
+    finding = transformer.transform_finding(finding_details)
+    f = CVEFinding(**finding).model_dump(mode='json', exclude_none=True)
+    assert compare_dicts(f, tnx_finding)
+
+
+def test_derive_system_type(transformer):
+    assert transformer.derive_system_type('windows2022') == 'WINDOWS'
+    assert transformer.derive_system_type('linux') == 'LINUX'
+    assert transformer.derive_system_type('macos') == 'MAC_OS'
+    assert transformer.derive_system_type('centos') == 'UNKNOWN'


### PR DESCRIPTION
# Description

- Implemented functionality to fetch vulnerabilities from CrowdStrike Falcon.  
- Integrated ingestion of fetched vulnerabilities into Tenable One.  
- Added pytest test cases for the newly implemented functionality. 

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# How Has This Been Tested?
### Manual Testing:
I have tested my code by passing different parameters at runtime. Below are the test scenarios I covered:
- **Importing only assets**: Set the import_findings flag to False and verified that only assets were imported.
- **Importing assets and findings**: Set the import_findings flag to True and verified that findings were also added.
- **Testing with last_seen_days**: Set last_seen_days to a value greater than 1 and observed an increase in the data count.

### Automated Tests:
- **test_findings_vulns_without_filter:**
   This test case does not apply any filters while retrieving vulnerabilities, relying on the default filter settings.
- **test_findings_vulns_with_filter:**
   This test case explicitly sets parameters like limit and last_seen_days to verify the function's behavior with different values.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
